### PR TITLE
feat(prototype): added support for setting protype

### DIFF
--- a/prototype.js
+++ b/prototype.js
@@ -10,6 +10,11 @@
   }
 })([], this, function() {
   return function(result, data) {
-    result.prototype[data.key] = data.value;
+    if (data.key === "prototype") {
+      result.prototype = data.value;
+    }
+    else {
+      result.prototype[data.key] = data.value;
+    }
   }
 });

--- a/tests/create.js
+++ b/tests/create.js
@@ -133,18 +133,27 @@
 
     QUnit.module("mu-create/create#property");
 
-    QUnit.test("prototype", function (assert) {
+    QUnit.test("prototype instance", function (assert) {
         assert.expect(1);
+        var p = {};
 
         var C = create(proto)({
-            "a": 1,
-            "b": 2
+            "prototype": p
         });
 
-        assert.propEqual(C.prototype, {
+        assert.strictEqual(C.prototype, p, "instance is equal");
+    });
+
+    QUnit.test("prototype property", function (assert) {
+        assert.expect(1);
+        var p = {
             "a": 1,
             "b": 2
-        });
+        }
+
+        var C = create(proto)(p);
+
+        assert.propEqual(C.prototype, p, "properies are equal");
     });
 
     QUnit.test("regexp", function(assert) {


### PR DESCRIPTION
If you want to set the _actual_ `prototype` you can now do so by providing a spec with the `prototype` key provided to  `mu-create/prototype`:

``` javascript
var p = {
  "log": function(m) {
    console.log(m);
  }
};

var C = create(proto, {
  "prototype": p
});

var c = C();

c.log("testing"); // logs "testing"
```
